### PR TITLE
Managed Device Renaming for tty or usb serial ports

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
@@ -227,8 +227,8 @@ def settings_diff(exported_settings, new_settings, skip_keys):
 
             # Add unidentified field or changed values
             # the import_settings fails if this field doesn't exist
-            if not any(line in s for s in exported_settings):
-               diff.append(line)
+            if not any(line.strip() in s.strip() for s in exported_settings):
+               diff.append(line.strip())
 
     return diff
 
@@ -511,7 +511,10 @@ def format_settings(path, in_dict):
             if type(value) is dict:
                 out_list.extend( format_settings(f'{path}/{key}', value) )
             else:
-                out_list.append(f"{path} {key}={value}")
+                if type(value) is str and " " in value:
+                    out_list.append(f"{path} {key}=\'{value}\'")
+                else:
+                    out_list.append(f"{path} {key}={value}")
     return out_list
 
 def get_skip_keys(new_settings, exported_all_settings):

--- a/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
@@ -137,8 +137,8 @@ def export_settings(cli_path):
         if "=" in line:
             keypath, value = line.split('=', 1)
             if line[0] != '#':
-                settings.append(line.replace("\\r","").replace("\\n","").replace("\"","'"))
-                all_settings.append(line.replace("\\r","").replace("\\n","").replace("\"","'"))
+                settings.append(line.replace("\\r","").replace("\\n","").replace("\"","'").strip())
+                all_settings.append(line.replace("\\r","").replace("\\n","").replace("\"","'").strip())
             else:
                 if value == '':
                     settings.append(line[1:])   # add empty value
@@ -504,6 +504,85 @@ def run_option(option, run_opt):
         result['message'] = 'No change required'
     return result
 
+def run_option_no_diff(option, run_opt):
+    """Applies the option on the Nodegrid
+
+    Applies the option on the Nodegrid following these steps:
+        1. Convert the option in a list of settings
+        2. Import all the settings on the Nodegrid
+
+    Args:
+        option (dict): Option to apply
+        run_opt (dict): Dictionary with extra import options
+
+    Returns:
+        dict: Result of import
+    """
+    suboptions = option['suboptions']
+    cli_path = option['cli_path']
+    skip_invalid_keys = run_opt['skip_invalid_keys']
+    check_mode = run_opt['check_mode']
+    use_config_start_global = run_opt['use_config_start_global']
+
+    result = dict(
+        changed=False,
+        failed=False,
+        message='',
+        export_result='',
+        skip_keys = []
+    )
+
+    # Get or format settings
+    diff = []
+    if 'settings' in option:
+        diff = option['settings']
+    else:
+        diff = format_settings(cli_path, suboptions)
+
+    # The module supports diff mode, which will display the configuration
+    # changes which will be performed on the connection
+    prepared_output = str()
+    for item in diff:
+        prepared_output += item + "\r\n"
+    result['diff'] = prepared_output
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if check_mode:
+        result['changed'] = True
+        return result
+
+    # manipulate or modify the state as needed (this is going to be the
+    # part where your module will do what it needs to do)
+    if len(diff) > 0:
+        result['changed'] = True
+        if 'import_func' in option:
+            import_func = option['import_func']
+            import_result = import_func(data=dict(
+                option=option,
+                run_opt=run_opt,
+                exported_settings=exported_settings,
+                diff=diff,
+                use_config_start=use_config_start_global
+            ))
+        else:
+            import_result = import_settings(diff, use_config_start=use_config_start_global)
+
+        result['import_result'] = import_result
+        if import_result['import_status'] == 'succeeded':
+            result['message'] = 'Import was successful'
+        else:
+            if len(import_result['error_list']) > 0:
+                result['message'] = ', '.join(import_result['error_list'])
+            result['msg'] = 'Import failed'
+            result['failed'] = True
+            return result
+    else:
+        result['changed'] = False
+        result['message'] = 'No change required'
+    return result
+
 def format_settings(path, in_dict):
     out_list = []
     if type(in_dict) is dict:
@@ -560,3 +639,31 @@ def read_table_row(table, col_index, col_value):
         if row[col_index] == col_value:
             return row
     return None
+
+def read_path_option(cli_path, option):
+    cmd = f"show {cli_path} {option}"
+    cmd_cli = pexpect.spawn('cli', encoding='UTF-8')
+    cmd_cli.setwinsize(500, 10000)
+    cmd_cli.expect_exact('/]# ')
+    cmd_cli.sendline('.sessionpageout undefined=no')
+    cmd_cli.expect_exact('/]# ')
+    cmd_cli.sendline(cmd)
+    cmd_cli.expect_exact('/]# ')
+    output = cmd_cli.before
+    cmd_cli.close()
+    if "Error" in output or "error" in output:
+        return "error", output
+    else:
+        result = {
+            "path": cli_path,
+            "option": option,
+            "value": ""
+        }
+
+        for line in output.splitlines()[1:-1]:
+            if len(line) > 0:
+                row = line.split("=")
+                if len(row) > 0:
+                    result["value"] = row[1].strip()
+
+    return "successful", result

--- a/collections/ansible_collections/zpe/nodegrid/plugins/modules/managed_devices.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/modules/managed_devices.py
@@ -49,7 +49,7 @@ def run_option_device(option, run_opt):
         # /settings/devices/ttyS1-router1 {spm_rename},ttyS1,spm_name
         #
         # Validate 'port_name' format against the pattern ttyS{numbers} or usbS{numbers}-{numbers}
-        pattern = re.compile("^ttyS([0-9]+)$|^usbS([0-9]-[0-9]+)$")
+        pattern = re.compile("^ttyS([0-9]+)$|^ttyS([0-9]+)-([0-9]+)$|^usbS([0-9])$|^usbS([0-9]+-[0-9]+)$")
         if pattern.match(port_name):
             new_name = suboptions['access']['name'].strip()
             suboptions['access'].pop('name')

--- a/collections/ansible_collections/zpe/nodegrid/plugins/modules/managed_devices.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/modules/managed_devices.py
@@ -18,9 +18,10 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.zpe.nodegrid.plugins.module_utils.nodegrid_util import check_os_version_support, run_option, format_settings, field_exist, result_failed, to_list, get_shell
+from ansible_collections.zpe.nodegrid.plugins.module_utils.nodegrid_util import check_os_version_support, run_option, format_settings, field_exist, result_failed, to_list, get_shell, get_cli, close_cli, execute_cmd, read_table, read_table_row
 
-import os, json, pexpect
+
+import os, json, pexpect, re
 
 # We have to remove the SID from the Environmental settings, to avoid an issue
 # were we can not run pexpect.run multiple times
@@ -33,6 +34,8 @@ def run_option_device(option, run_opt):
     suboptions = option['suboptions']
     cli_path = option['cli_path']
     settings_list = []
+    cmd_results = None
+    change_name_message = None
 
     if not ('access' in suboptions and field_exist(suboptions['access'], 'name')):
         return result_failed("Field 'access/name' is required")
@@ -41,11 +44,42 @@ def run_option_device(option, run_opt):
         port_name = suboptions['access']['port_name']
         suboptions['access'].pop('port_name')
         cli_path += f"/{port_name}"
+
+        # Change managed device name supported only for devices connected through tty or usb (local_serial / usb_serial)
+        # The name is changed based on an specific cli command (i.e., no via import_settings). For example:
+        # /settings/devices/ttyS1-router1 {spm_rename},ttyS1,spm_name
+        #
+        # Validate 'port_name' format against the pattern ttyS{numbers} or usbS{numbers}-{numbers}
+        pattern = re.compile("^ttyS([0-9]+)$|^usbS([0-9]-[0-9]+)$")
+        if pattern.match(port_name):
+            new_name = suboptions['access']['name'].strip()
+            suboptions['access'].pop('name')
+            devices_table = read_table("/settings/devices")
+            if devices_table[0] == 'error':
+                return result_failed(f"Failed to get device table on cli: 'show /settings/devices'. Error: {devices_table[1]}")
+            # Devices table header
+            # 'name'  'connected through'  'type'  'access'  'monitoring'
+            device = read_table_row(devices_table[1], 1, port_name)
+            if device is None:
+                return result_failed(f"Device port '{port_name}' does not exist!")
+            current_name = device[0]
+            if new_name != current_name:
+                cmds = [{'confirm': True,'cmd': f"cd /settings/devices; rename {port_name}; set new_name={new_name}"}]
+                cmd_results = list()
+                cmd_result = dict()
+                try:
+                    cmd_cli = get_cli(timeout=30)
+                    for cmd in cmds:
+                        cmd_result = execute_cmd(cmd_cli, cmd)
+                        cmd_results.append(cmd_result)
+                    close_cli(cmd_cli)
+                    change_name_message = f"managed_device_name: {current_name} -> {new_name}"
+                except Exception as exc:
+                    return result_failed(f"Failed changing name device '{port_name}' with name '{new_name}'. Results: f{cmd_results}")
     else:
         cli_path += f"/{suboptions['access']['name']}"
 
     for key, value in suboptions.items():
-
         if key == 'name':
             print("Rename Port")
 
@@ -69,7 +103,17 @@ def run_option_device(option, run_opt):
         
     option['cli_path'] = cli_path
     option['settings'] = settings_list
-    return run_option(option, run_opt)
+    result = run_option(option, run_opt)
+
+    # If device named was changed, update the return result
+    if cmd_results:
+        result['cmds_output'] = cmd_results
+        result['changed'] = True
+        if result['message'] == 'No change required':
+            result['message'] = change_name_message
+        else:
+            result['message'] += f" | {change_name_message}"
+    return result
 
 def run_option_auto_discovery(option, run_opt):
     suboptions = option['suboptions']

--- a/collections/ansible_collections/zpe/nodegrid/roles/system_preferences/tasks/sys_preferences.yml
+++ b/collections/ansible_collections/zpe/nodegrid/roles/system_preferences/tasks/sys_preferences.yml
@@ -11,11 +11,11 @@
   zpe.nodegrid.system:
       preferences:
         show_hostname_on_webui_header: "{{ sys_show_hostname_on_webui_header }}"
-  when: "{{ sys_show_hostname_on_webui_header }} == no"
+  when: sys_show_hostname_on_webui_header == "no"
 
 - name: Update Hostname in WebUI
   zpe.nodegrid.system:
       preferences:
         show_hostname_on_webui_header: "{{ sys_show_hostname_on_webui_header }}"
         webui_header_hostname_color: "{{ sys_webui_header_hostname_color }}"
-  when: "{{ sys_show_hostname_on_webui_header }} == yes "
+  when: sys_show_hostname_on_webui_header == "yes"

--- a/collections/ansible_collections/zpe/nodegrid/roles/system_preferences/tasks/sys_session_logging.yml
+++ b/collections/ansible_collections/zpe/nodegrid/roles/system_preferences/tasks/sys_session_logging.yml
@@ -1,5 +1,5 @@
 - name: Setup System Session Logging
   zpe.nodegrid.import_settings:
     cmds:
-          - "/settings/system_logging enable_session_logging={{system_logging_enable_session_logging}}"
-          - "/settings/system_logging enable_session_logging_alerts={{system_logging_enable_session_logging_alerts}}"
+      - "/settings/system_logging enable_session_logging={{system_logging_enable_session_logging}}"
+      - "/settings/system_logging enable_session_logging_alerts={{system_logging_enable_session_logging_alerts}}"

--- a/examples/playbooks/managed_devices/md_create_device.yml
+++ b/examples/playbooks/managed_devices/md_create_device.yml
@@ -4,12 +4,131 @@
     - zpe.nodegrid
 
   tasks:
-  - name: Add device
+  - name: Add ttyS1 device
+    zpe.nodegrid.managed_devices:
+      device:
+        access:
+          name: "ttyS1-router1"
+          port_name: "ttyS1"
+          description: "serial console to router1"
+          launch_url_via_html5: "yes"
+          password: "password"
+          allow_pre-shared_ssh_key: "no"
+          baud_rate: 9600
+          parity: "None"
+          flow_control: "None"
+          data_bits: 7
+          stop_bits: 1
+          rs-232_signal_for_device_state_detection: "Auto"
+          enable_device_state_detection_based_in_data_flow: "no"
+          enable_hostname_detection: "no"
+          multisession: "yes"
+          read-write_multisession: "no"
+          enable_serial_port_settings_via_escape_sequence: "yes"
+          icon: "terminal.png"
+          mode: "enabled"
+          skip_authentication_to_access_device: "no"
+          escape_sequence: "^Ec"
+          power_control_key: "^O"
+          show_text_information: "yes"
+          enable_ip_alias: "no"
+          enable_second_ip_alias: "no"
+          allow_ssh_protocol: "yes"
+          allow_telnet_protocol: "yes"
+          telnet_port: 7001
+          allow_binary_socket: "no"
+        management:
+          monitoring_nominal: "no"
+        logging:
+          data_logging: "yes"
+          enable_data_logging_alerts: "no"
+        custom_fields:
+          - field_name: "dummy1"
+            field_value: "1234"
+          - field_name: "dummy2"
+            field_value: "444"
+        commands:
+          - command: "console"
+            enabled: "yes"
+            launch_local_application: "no"
+          - command: "data_logging"
+            enabled: "yes"
+
+  - name: Add ttyS2 device
+    zpe.nodegrid.managed_devices:
+      device:
+        access:
+          name: "ttyS2-switch1"
+          port_name: "ttyS2"
+          description: "serial console to switch1"
+
+  - name: Add usbS0-1 device
+    zpe.nodegrid.managed_devices:
+      device:
+        access:
+          name: "TemperatureSensor"
+          port_name: "usbS0-1"
+          description: "Temperature Sensor"
+          address_location: "address"
+          launch_url_via_html5: "yes"
+          username: "admin"
+          password: "admin"
+          allow_pre-shared_ssh_key: "no"
+          baud_rate: 9600
+          parity: "None"
+          flow_control: "None"
+          data_bits: 8
+          stop_bits: 1
+          rs-232_signal_for_device_state_detection: "Auto"
+          enable_device_state_detection_based_in_data_flow: "no"
+          enable_hostname_detection: "no"
+          multisession: "yes"
+          read-write_multisession: "no"
+          enable_serial_port_settings_via_escape_sequence: "yes"
+          map_to_virtual_machine: "no"
+          icon: "terminal.png"
+          escape_sequence: "^Ec"
+          power_control_key: "^O"
+          show_text_information: "yes"
+          enable_ip_alias: "no"
+          enable_second_ip_alias: "no"
+          allow_ssh_protocol: "yes"
+          ssh_port: 22102
+          allow_telnet_protocol: "yes"
+          telnet_port: 7009
+          allow_binary_socket: "no"
+        management:
+          monitoring_nominal: "no"
+        logging:
+          data_logging: "yes"
+          enable_data_logging_alerts: "no"
+        custom_fields:
+          - field_name: "dummy1"
+            field_value: "1234"
+          - field_name: "dummy2"
+            field_value: "444"
+        commands:
+          - command: "console"
+            enabled: "yes"
+            launch_local_application: "no"
+          - command: "data_logging"
+            enabled: "yes"
+
+  - name: Add usbS0-2 device
+    zpe.nodegrid.managed_devices:
+      device:
+        access:
+          name: "HumiditySensor"
+          port_name: "usbS0-2"
+          description: "Humidity Sensor"
+
+  - name: Add ilo device
     zpe.nodegrid.managed_devices:
       device:
         access:
           name: "NSC"
           type: "ilo"
+          description: "NSC ilo managed device"
           ip_address: "192.168.42.223"
           credential: "set_now"
           username: "admin"
@@ -36,4 +155,3 @@
             enabled: "yes"
           - command: "power"
             enabled: "yes"
-          

--- a/examples/playbooks/security/sec_authentication_add_servers.yml
+++ b/examples/playbooks/security/sec_authentication_add_servers.yml
@@ -49,8 +49,18 @@
               radius_retries: "2"
               radius_enable_servicetype: "no"
             - number: 3
-              2-factor_authentication: "none"
-              status: "enabled"
-              apply_2-factor_auth_for_admin_and_root_users: "no"
+              method: "ldap_or_ad"
+              status: "disabled"
+              fallback_if_denied_access: "yes"
+              remote_server: "10.1.1.7"
+              authorize_ssh_pkey_users: "yes"
+              ldap_ad_base: ""
+              ldap_ad_login_attribute: ""
+              ldap_ad_secure: "off"
+              ldap_ad_database_username: "db_username"
+              ldap_ad_database_password: "db_pass"
+              ldap_ad_group_attribute: ""
+              ldap_ad_search_filter: ""
+              ldap_port: "389"
 
 


### PR DESCRIPTION
**Add support for renaming a managed device that is connected through a ttyS or usb serial port.**

The name is changed based on an specific 'cli' command which considers the 'connected through' port, not its 'name'. The device is uniquely identified by the 'port_name', like for example 'ttyS1' or 'usbS0-1'. 

For example, to change the device name to 'ttyS1-router1' that is connected through 'ttyS1' the following 'cli' command is executed:
  /settings/devices/ttyS1-router1 {spm_rename},ttyS1,spm_name

Additionally:
- Extend the Ansible playbook example '/md_create_device.yml' to consider ttyS and usbS devices
- The 'description' field might contain spaces and this impacts on the way export/import settings work. Control this on the settings 'diff'

Files modified:
 - collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
 - collections/ansible_collections/zpe/nodegrid/plugins/modules/managed_devices.py
 - examples/playbooks/managed_devices/md_create_device.yml