### PR TITLE
Fixed actions by adding fqcn on execute_module

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/delete_settings.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/delete_settings.py
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
                     cmds.append({'cmd': f"delete " + str(item), 'confirm':True } )
         cmd_args = dict(cmds=cmds)
         if len(cmds) > 0:
-            response = self._execute_module(module_name='nodegrid_cmds', module_args=cmd_args)
+            response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args)
             if 'cmds_output' in response.keys():
                 return self._result_changed(msg=str(response['cmds_output']))
             else:

--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/export_settings.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/export_settings.py
@@ -137,7 +137,7 @@ class ActionModule(ActionBase):
             cmd_args = dict(
                 cmds=cmds
             )
-        response = self._execute_module(module_name='nodegrid_cmds', module_args=cmd_args)
+        response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args)
         if 'cmds_output' in response.keys():
             all_lines = list()
             for cmd_output in response['cmds_output']:

--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/facts.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/facts.py
@@ -16,7 +16,7 @@ class ActionModule(ActionBase):
     def _run_command(self, cmds):
         result = dict()
         if len(cmds) >0:
-            response = self._execute_module(module_name='nodegrid_cmds', module_args=cmds, task_vars=self._task_vars)
+            response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmds, task_vars=self._task_vars)
             if 'cmds_output' in response.keys():
                 result["failed"] = False
                 result['result'] = response


### PR DESCRIPTION
The actions fixed in this PR can't execute the module nodegrid_cmds if the collection is installed into the default collection path.