### PR TITLE
Fixed install ssh key and sudo access in the setup module

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/setup.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/setup.py
@@ -238,8 +238,8 @@ class ActionModule(ActionBase):
         self._expect_for(conn_obj, [':~$ ', ':~# '])
 
         # Check if the ssh key is already installed
-        conn_obj.sendline(f"grep -q '{ssh_key}' /home/{ssh_key_user}/.ssh/authorized_keys ; echo $?")
-        ret = self._expect_for(conn_obj, ['0', '1', ':~$ ', ':~# '])
+        conn_obj.sendline(f"grep -q '{ssh_key}' /home/{ssh_key_user}/.ssh/authorized_keys && echo _SUCCESS_ >&2 || echo _FAIL_ >&2")
+        ret = self._expect_for(conn_obj, ['_SUCCESS_', '_FAIL_', ':~$ ', ':~# '])
         if ret == 0:
             display.vvv(f"SSH key already installed")
             self._expect_for(conn_obj, [':~$ ', ':~# '])
@@ -272,8 +272,8 @@ class ActionModule(ActionBase):
             self._expect_for(conn_obj, [':~$ ', ':~# '])
 
         # Check if sudo permissions is granted
-        conn_obj.sendline(f"[ -f /etc/sudoers.d/{sudo_user} ] ; echo $?")
-        ret = self._expect_for(conn_obj, ['0', '1', ':~$ ', ':~# '])
+        conn_obj.sendline(f"[ -f /etc/sudoers.d/{sudo_user} ] && echo _SUCCESS_ >&2 || echo _FAIL_ >&2")
+        ret = self._expect_for(conn_obj, ['_SUCCESS_', '_FAIL_', ':~$ ', ':~# '])
         if ret == 0:
             display.vvv(f"Sudo permissions already granted")
             self._expect_for(conn_obj, [':~$ ', ':~# '])

--- a/examples/playbooks/setup/setup_install_ssh_key.yml
+++ b/examples/playbooks/setup/setup_install_ssh_key.yml
@@ -50,6 +50,7 @@
        ansible.builtin.shell: ssh-keygen -lf {{ ssh_public_key_filepath }}
        register: ssh_keygen
        connection: local
+       changed_when: false
      
      - name: Get ssh_key_type
        set_fact:
@@ -77,5 +78,4 @@
          ansible_ssh_user: "{{ ssh_key_user }}" # Avoids conflict with the legacy variable
          ansible_ssh_private_key_file: "{{ ssh_private_key_filepath }}"
        ansible.builtin.raw: whoami
-       register: result
-       changed_when: False
+       changed_when: false

--- a/examples/playbooks/setup/setup_install_ssh_key.yml
+++ b/examples/playbooks/setup/setup_install_ssh_key.yml
@@ -74,5 +74,8 @@
      - name: Validate Connection
        vars:
          ansible_user: "{{ ssh_key_user }}"
+         ansible_ssh_user: "{{ ssh_key_user }}" # Avoids conflict with the legacy variable
          ansible_ssh_private_key_file: "{{ ssh_private_key_filepath }}"
-       ansible.builtin.ping:
+       ansible.builtin.raw: whoami
+       register: result
+       changed_when: False


### PR DESCRIPTION
Fixes:
- (ssh key install and grant sudo access) Send the exit code to `stderr` when using the `echo` command with `pexpect` in the `setup.py` module. It's a workaround for some Nodegrid versions.
- Changed the connection validation in the playbook `setup_install_ssh_key.yml` to use the Ansible `raw` module instead of `ping` module, this way, the validation will also work for users whose start application is CLI.