### PR TITLE
Fixed action modules by adding task_vars to the _execute_module call

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/delete_settings.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/delete_settings.py
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
                     cmds.append({'cmd': f"delete " + str(item), 'confirm':True } )
         cmd_args = dict(cmds=cmds)
         if len(cmds) > 0:
-            response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args)
+            response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args, task_vars=self._task_vars)
             if 'cmds_output' in response.keys():
                 return self._result_changed(msg=str(response['cmds_output']))
             else:

--- a/collections/ansible_collections/zpe/nodegrid/plugins/action/export_settings.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/action/export_settings.py
@@ -137,7 +137,7 @@ class ActionModule(ActionBase):
             cmd_args = dict(
                 cmds=cmds
             )
-        response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args)
+        response = self._execute_module(module_name='zpe.nodegrid.nodegrid_cmds', module_args=cmd_args, task_vars=self._task_vars)
         if 'cmds_output' in response.keys():
             all_lines = list()
             for cmd_output in response['cmds_output']:


### PR DESCRIPTION
Fixed Ansible delegation not working with the module zpe.nodegrid.export_settings.