### PR TITLE
Fix typo on the Authentication Add Servers example playbook

### DIFF
--- a/examples/playbooks/security/sec_authentication_add_servers.yml
+++ b/examples/playbooks/security/sec_authentication_add_servers.yml
@@ -66,7 +66,7 @@
 
   - name: Authentication Add Servers
     zpe.nodegrid.security:
-        authentication:
+        authentication_servers:
           servers: "{{ servers }}"
   
   - name: Validate Authentication Servers


### PR DESCRIPTION
Fix typo on the Authentication Add Servers example playbook.