### PR TITLE
Add bonding type support to the network_connections in the Nodegrid Ansible collections

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/modules/network.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/modules/network.py
@@ -599,23 +599,14 @@ def run_option_network_connections(option, run_opt):
                 # For those mismatched values, collect associated settings for deletion,
                 # but only if they aren’t already valid under the current suboption value.
                 if isinstance(dependencies[dependency], dict):
-                    for dep_rem in {
-                        key:value
-                        for key, value in dependencies[dependency].items()
-                        if dependency in suboptions and key not in [suboptions[dependency]]
-                    }:
+                    for dep_rem in {key:value for key, value in dependencies[dependency].items() if dependency in suboptions and key not in [suboptions[dependency]]}:
                         for setting in dependencies[dependency][dep_rem]:
-                            if (suboptions[dependency] not in dependencies[dependency]) or \
-                               (setting not in dependencies[dependency][suboptions[dependency]]):
+                            if (suboptions[dependency] not in dependencies[dependency]) or (setting not in dependencies[dependency][suboptions[dependency]]):
                                 settings_tobe_deleted.add(setting)
 
                 # Elif the dependency is a list and the suboption is explicitly set to "no",
                 # mark all associated settings for deletion.
-                elif (
-                        isinstance(dependencies[dependency], list)
-                        and dependency in suboptions
-                        and suboptions[dependency].lower() == "no"
-                    ):
+                elif isinstance(dependencies[dependency], list) and dependency in suboptions and suboptions[dependency].lower() == "no":
                     for setting in dependencies[dependency]:
                         settings_tobe_deleted.add(setting)
 

--- a/collections/ansible_collections/zpe/nodegrid/plugins/modules/network.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/modules/network.py
@@ -318,6 +318,7 @@ def run_option_network_settings(option, run_opt):
         suboptions.pop('enable_network_failover', None)
     return run_option(option, run_opt)
 
+
 def run_option_network_connections(option, run_opt):
     # Settings to be deleted/discarded if empty
     settings_to_delete_if_empty = [

--- a/collections/ansible_collections/zpe/nodegrid/roles/network_connections/tasks/network_connections.yml
+++ b/collections/ansible_collections/zpe/nodegrid/roles/network_connections/tasks/network_connections.yml
@@ -59,7 +59,7 @@
       ensure_connection_is_up: "{{ connection.ensure_connection_is_up | default('no') }}"
       ip_address: "{{ connection.ip_address | default('') }}"
       interval: "{{ connection.interval | default(24) }}" # between 1 and 24
-      # ---
+      # --
 
       # type: bonding
        # bonding_mode: '802.3ad(lacp)', 'adaptive_load_balancing, 'broadcast', 'xor_load_balancing', 'active_backup', 'adaptive_transmit_load_balancing', 'round-robin'

--- a/collections/ansible_collections/zpe/nodegrid/roles/network_connections/tasks/network_connections.yml
+++ b/collections/ansible_collections/zpe/nodegrid/roles/network_connections/tasks/network_connections.yml
@@ -59,7 +59,27 @@
       ensure_connection_is_up: "{{ connection.ensure_connection_is_up | default('no') }}"
       ip_address: "{{ connection.ip_address | default('') }}"
       interval: "{{ connection.interval | default(24) }}" # between 1 and 24
-      # --
+      # ---
+
+      # type: bonding
+       # bonding_mode: '802.3ad(lacp)', 'adaptive_load_balancing, 'broadcast', 'xor_load_balancing', 'active_backup', 'adaptive_transmit_load_balancing', 'round-robin'
+      bonding_mode: "{{ connection.bonding_mode | default('active_backup') }}"
+      slaves: "{{ connection.slaves | default('eth1') }}"
+      link_monitoring: "{{ connection.link_monitoring | default('mii') }}" # 'mii', 'arp'
+      monitoring_frequency: "{{ connection.monitoring_frequency | default('100') }}"
+      link_up_delay: "{{ connection.link_up_delay | default('0') }}"
+      link_down_delay: "{{ connection.link_down_delay | default('0') }}"
+      system_priority: "{{ connection.system_priority | default('0') }}"
+      actor_mac_address: "{{ connection.actor_mac_address | default('') }}"
+      user_port_key: "{{ connection.user_port_key | default('0') }}"
+      lacp_rate: "{{ connection.lacp_rate | default('slow') }}" # 'fast', 'slow'
+      aggregation_selection_logic: "{{ connection.aggregation_selection_logic | default('stable') }}" # 'bandwith', 'count', 'stable'
+      transmit_hash_policy: "{{ connection.transmit_hash_policy | default('layer_2') }}" # 'layer_2', 'layers_2_and_3', 'layers_2_and_3_and_encap', 'layers_3_and_4', 'layers_3_and_4_and_encap'
+      bond_mac_configuration: "{{ connection.bond_mac_configuration | default('bond_fail-over-mac') }}" # 'bond_custom_mac', 'bond_fail-over-mac'
+      bond_fail-over-mac_policy: "{{ connection['bond_fail-over-mac_policy'] | default('none') }}" # 'none', 'current_active_interface', 'follow_active_interface', primary_interface'
+      bond_mac_address: "{{ connection.bond_mac_address | default('') }}"
+      # ---
+
       # SIM-1
       sim-1_phone_number: "{{ connection['sim-1_phone_number'] | default('') }}"
       sim-1_apn_configuration: "{{ connection['sim-1_apn_configuration'] | default('manual') }}" # manual, automatic


### PR DESCRIPTION
## Description
This merge request adds support for the Network Connection Bonding type under the `network_connection` role in the Nodegrid Ansible collection. 

## Changes Made
Add support to the `network_connections.yml` role, with the necessary changes in the `network.py` module.

## Related Issues
Support case: SPE-661

## Performed Tests
- Playbook:
```yml
nodegrid_roles:
  - local_peer

network_connections:
  - name: "lacp"
    type: 'bonding'
    bonding_mode: '802.3ad(lacp)'
    bond_mac_configuration: 'bond_fail-over-mac'
    slaves: "sfp0 sfp1"
    bond_fail-over-mac_policy: 'current_active_interface'
    configure_hostname_through_dhcp: 'yes'
    description: 'Bonding_Lacp'
    set_as_primary_connection: 'yes'
    connect_automatically: 'yes'
    ipv4_mode: 'no_ipv4_address'
    ipv6_mode: 'no_ipv6_address'
    enable_lldp: 'yes'
```

- Test executed:
```shell
> ansible-playbook /etc/ansible/playbooks/examples/system-roles/IMI/102_role_local_peer.yaml -l NSR_45.82 --tags network_connections 
PLAY [Configure a Nodegrid as Local Peer] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************
ok: [NSR_45.82]

TASK [Setup Network Connections] ***********************************************************************************************************************************************************************************************************

TASK [zpe.nodegrid.network_connections : Configure Ethernet IPv4 Connections] **************************************************************************************************************************************************************
changed: [NSR_45.82] => (item={'name': 'lacp', 'type': 'bonding', 'bonding_mode': '802.3ad(lacp)', 'bond_mac_configuration': 'bond_fail-over-mac', 'slaves': 'sfp0 sfp1', 'bond_fail-over-mac_policy': 'current_active_interface', 'configure_hostname_through_dhcp': 'yes', 'description': 'Bonding_Lacp', 'set_as_primary_connection': 'yes', 'connect_automatically': 'yes', 'ipv4_mode': 'no_ipv4_address', 'ipv6_mode': 'no_ipv6_address', 'enable_lldp': 'yes'})

PLAY RECAP *********************************************************************************************************************************************************************************************************************************
NSR_45.82                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

- Verified the changes applied via the Ansible playbook through the CLI to ensure they were successfully implemented:
```shell
[admin@nodegrid network_connections]# show
  name          status      type                  interface   carrier state  ipv4 address       ipv6 address                  mac address        description
  ============  ==========  ====================  ==========  =============  =================  ============================  =================  =================================
  BACKPLANE0    connected   ethernet              backplane0  up             192.168.163.10/24  fe80::e61a:2cff:fe00:752e/64  e4:1a:2c:00:75:2e
  BACKPLANE1    connected   ethernet              backplane1  up             192.168.164.10/24  fe80::e61a:2cff:fe00:752f/64  e4:1a:2c:00:75:2f
  CELLULAR-4-A  connected   mobile broadband gsm  cdc-wdm6    up             191.15.134.162/30                                                   autogenerated cellular connection
  ETH0          connected   ethernet              eth0        up             192.168.45.82/24   fe80::e61a:2cff:fe00:752c/64  e4:1a:2c:00:75:2c
  ETH1          not active  ethernet              eth1        down                                                            e4:1a:2c:00:75:2d
  hotspot       not active  wifi                              down
  lacp          not active  bonding               bond0       down                                                                               Bonding_Lacp
[admin@nodegrid network_connections]#
[admin@nodegrid network_connections]# cd lacp/
[admin@nodegrid lacp]# show
name: lacp
type: Bonding
interface: bond0
description = Bonding_Lacp
connect_automatically = yes
set_as_primary_connection = yes
enable_lldp = no
block_unsolicited_incoming_packets = no
configure_hostname_through_dhcp = no
bonding_mode = 802.3ad(lacp)
primary_interface = eth0
secondary_interface = eth0
slaves = sfp0 sfp1
link_monitoring = mii
monitoring_frequency = 100
link_up_delay = 0
link_down_delay = 0
arp_target =
arp_validate = none
bond_mac_configuration = bond_fail-over-mac
bond_fail-over-mac_policy = current_active_interface
system_priority = 0
actor_mac_address =
user_port_key = 0
lacp_rate = slow
aggregation_selection_logic = stable
transmit_hash_policy = layer_2
ipv4_mode = no_ipv4_address
ipv4_dns_server =
ipv4_dns_search =
ipv4_default_route_metric = 90
ipv4_ignore_obtained_default_gateway = no
ipv4_ignore_obtained_dns_server = no
ipv6_mode = no_ipv6_address
ipv6_dns_server =
ipv6_dns_search =
ipv6_default_route_metric = 90
ipv6_ignore_obtained_default_gateway = no
ipv6_ignore_obtained_dns_server = no
[admin@nodegrid lacp]#
```