### PR TITLE
[Ansible] Fix libvirt community installation

### DIFF
--- a/nodegrid_install.yml
+++ b/nodegrid_install.yml
@@ -110,10 +110,7 @@
           shell: 'ansible-galaxy collection install -r ./build/collections/requirements.yml -p /etc/ansible/collections'
 
         - name: Install community.libvirt collection
-          ansible.builtin.ansible_galaxy:
-            command: collection
-            name: community.libvirt
-            state: present
+          shell: ansible-galaxy collection install community.libvirt
           register: galaxy_result
           ignore_errors: yes
 


### PR DESCRIPTION
## Description
This merge request addresses an issue in `ansible.builtin.ansible_galaxy` to install `community.libvirt` collection.

## Changes Made
Run the installation via a shell command instead of using `ansible.builtin.ansible_galaxy`.

## Related Issues
SPE-751

## Testing Performed
```diff
TASK [Install community.libvirt collection] *******************************************************************************************************
+changed: [localhost]

. . .

PLAY RECAP ****************************************************************************************************************************************
localhost                  : ok=21   changed=5    unreachable=0    failed=0    skipped=12   rescued=0    ignored=0
```