### PR TITLE
Fix convert_to_json parsing function to correctly handle certificates

### DIFF
--- a/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
@@ -374,6 +374,8 @@ def split_in_two(line, separator):
 def convert_to_json(cli_output):
     # Detect if output is a table or not
     data = []
+    regex = rf'([a-zA-Z0-9 _-]+):\s*\r\n(?=.*?{re.escape(CERT_BEGIN)})'
+    cert_key = re.search(regex, cli_output)
 
     if "===" in cli_output:     #Table content
         details = []
@@ -424,7 +426,7 @@ def convert_to_json(cli_output):
             # Read certificate lines and store them in the details dictionary
             if CERT_BEGIN in cli_output and CERT_END in cli_output:
                 reading_cert, cert_lines, details = process_certificate_line(
-                    line, reading_cert, cert_lines, details
+                    line, reading_cert, cert_lines, details, cert_key
                 )
                 if reading_cert: continue
 
@@ -447,7 +449,7 @@ def convert_to_json(cli_output):
             # Read certificate lines and store them in the details dictionary
             if CERT_BEGIN in cli_output and CERT_END in cli_output:
                 reading_cert, cert_lines, details = process_certificate_line(
-                    line, reading_cert, cert_lines, details
+                    line, reading_cert, cert_lines, details, cert_key
                 )
                 if reading_cert: continue
 
@@ -487,8 +489,8 @@ def convert_to_json(cli_output):
 
     return data
 
-def process_certificate_line(line, reading_cert, cert_lines, details):
-    if line == 'certificate:':
+def process_certificate_line(line, reading_cert, cert_lines, details, cert_key):
+    if line == cert_key.group(1):
         reading_cert = True
 
     elif CERT_BEGIN in line:
@@ -498,7 +500,7 @@ def process_certificate_line(line, reading_cert, cert_lines, details):
     elif CERT_END in line:
         cert_lines.append(line.rstrip('\r'))
         cert_lines.append("")
-        details['certificate'] = cert_lines[:]
+        details[cert_key.group(1)] = cert_lines[:]
         reading_cert = False
 
     elif reading_cert:

--- a/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
@@ -8,6 +8,9 @@ from datetime import datetime
 import os
 import uuid
 
+CERT_BEGIN = '-----BEGIN '
+CERT_END = '-----END '
+
 def _get_import_process_timeout(import_text):
     ret_timeout = 1500 # arbitrary default timeout
     count = 0
@@ -371,10 +374,6 @@ def split_in_two(line, separator):
 def convert_to_json(cli_output):
     # Detect if output is a table or not
     data = []
-    has_certificate = (
-        '-----BEGIN CERTIFICATE-----' in cli_output and
-        '-----END CERTIFICATE-----' in cli_output
-    )
 
     if "===" in cli_output:     #Table content
         details = []
@@ -423,7 +422,7 @@ def convert_to_json(cli_output):
         cert_lines = []
         for line in lines:
             # Read certificate lines and store them in the details dictionary
-            if has_certificate:
+            if CERT_BEGIN in cli_output and CERT_END in cli_output:
                 reading_cert, cert_lines, details = process_certificate_line(
                     line, reading_cert, cert_lines, details
                 )
@@ -446,7 +445,7 @@ def convert_to_json(cli_output):
         cert_lines = []
         for line in lines:
             # Read certificate lines and store them in the details dictionary
-            if has_certificate:
+            if CERT_BEGIN in cli_output and CERT_END in cli_output:
                 reading_cert, cert_lines, details = process_certificate_line(
                     line, reading_cert, cert_lines, details
                 )
@@ -492,11 +491,11 @@ def process_certificate_line(line, reading_cert, cert_lines, details):
     if line == 'certificate:':
         reading_cert = True
 
-    elif '-----BEGIN CERTIFICATE-----' in line:
+    elif CERT_BEGIN in line:
         reading_cert = True
         cert_lines.append(line.rstrip('\r'))
 
-    elif '-----END CERTIFICATE-----' in line:
+    elif CERT_END in line:
         cert_lines.append(line.rstrip('\r'))
         cert_lines.append("")
         details['certificate'] = cert_lines[:]

--- a/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
+++ b/collections/ansible_collections/zpe/nodegrid/plugins/module_utils/nodegrid_util.py
@@ -371,6 +371,10 @@ def split_in_two(line, separator):
 def convert_to_json(cli_output):
     # Detect if output is a table or not
     data = []
+    has_certificate = (
+        '-----BEGIN CERTIFICATE-----' in cli_output and
+        '-----END CERTIFICATE-----' in cli_output
+    )
 
     if "===" in cli_output:     #Table content
         details = []
@@ -415,7 +419,16 @@ def convert_to_json(cli_output):
     elif " = " in cli_output and "show" in cli_output:   # Settings Detected
         lines = cli_output.strip().split('\n')
         details = {}
+        reading_cert = False
+        cert_lines = []
         for line in lines:
+            # Read certificate lines and store them in the details dictionary
+            if has_certificate:
+                reading_cert, cert_lines, details = process_certificate_line(
+                    line, reading_cert, cert_lines, details
+                )
+                if reading_cert: continue
+
             if '=' in line:
                 key, value = split_in_two(line, '=')
                 details[key] = value
@@ -429,7 +442,16 @@ def convert_to_json(cli_output):
         lines = cli_output.strip().split('\n')
         details = {}
         path = ''
+        reading_cert = False
+        cert_lines = []
         for line in lines:
+            # Read certificate lines and store them in the details dictionary
+            if has_certificate:
+                reading_cert, cert_lines, details = process_certificate_line(
+                    line, reading_cert, cert_lines, details
+                )
+                if reading_cert: continue
+
             if ':' in line:
                 key, value = split_in_two(line, ':')
                 details[key] = value
@@ -465,6 +487,25 @@ def convert_to_json(cli_output):
     # #else:       # other output
 
     return data
+
+def process_certificate_line(line, reading_cert, cert_lines, details):
+    if line == 'certificate:':
+        reading_cert = True
+
+    elif '-----BEGIN CERTIFICATE-----' in line:
+        reading_cert = True
+        cert_lines.append(line.rstrip('\r'))
+
+    elif '-----END CERTIFICATE-----' in line:
+        cert_lines.append(line.rstrip('\r'))
+        cert_lines.append("")
+        details['certificate'] = cert_lines[:]
+        reading_cert = False
+
+    elif reading_cert:
+        cert_lines.append(line.rstrip('\r'))
+
+    return reading_cert, cert_lines, details
 
 def result_failed(msg):
     return {'failed': True, 'changed': False, 'msg': msg}


### PR DESCRIPTION
[NG-28700: [Ansible - GitHub] zpe.nodegrid.nodegrid_cmds output is broken when showing certificate data](https://zpesystems.atlassian.net/browse/NG-28700?focusedCommentId=400875)

## Description
This pull request addresses the issue where the `convert_to_json` function does not correctly handle certificates.

## Output result:
```JSON
"json": [
	{
		"data": {
			"certificate": [
				"-----BEGIN CERTIFICATE-----",
				"MIIHSTCCBTGgAwIBAgIUMn1/qcVv3h3ggm52+2Lb7semXdowDQYJKoZIhvcNAQEL",
				"BQAwgZcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEQMA4GA1UEBwwHRnJlbW9u",
				"dDEYMBYGA1UECgwPWlBFIFN5c3RlbXMgSW5jMREwDwYDVQQLDAhOb2RlR3JpZDEV",
				"MBMGA1UEAwwMZTQxYTJjMTAwMjYwMSUwIwYJKoZIhvcNAQkBFhZzdXBwb3J0QHpw",
				"ZXN5c3RlbXMuY29tMB4XDTI1MTAwODE3NDgyMVoXDTI4MDExMTE3NDgyMVowgZcx",
				"CzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEQMA4GA1UEBwwHRnJlbW9udDEYMBYG",
				"A1UECgwPWlBFIFN5c3RlbXMgSW5jMREwDwYDVQQLDAhOb2RlR3JpZDEVMBMGA1UE",
				"AwwMZTQxYTJjMTAwMjYwMSUwIwYJKoZIhvcNAQkBFhZzdXBwb3J0QHpwZXN5c3Rl",
				"bXMuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApNEZlNmxgYiK",
				"/vkkmjNSIz5Chbu35ynoIz9OhPwrBduG9AvaAj4KcGLm+UmtJlEzMEJZchJevYOM",
				"WivxZhQawMx19Y4F7mJxn1pYEckGJJMK0Q7H5d54A6Hi0R1Cpd8MWYlziP1OPGTN",
				"U7K4T6+LG8laJwOKRTOFFswRHrXDuV1kL4sSa9QxbQFe/zMaCarCMb0e2wJ64ig+",
				"K5i0g3loY0H46c/54ey8EMRePU9Lx5VsWesa0oRW5DnwWKFHt//vKXn9riuCFPNl",
				"/1ImmrFygjVL+m48m05hUoMHh3P+srd9jbl0oEL18qRCBJuLoDEAJacAtvQkoXUw",
				"wd3zzU1VebtBXxDDyZffkBM7DWGtP1AducdVGl9rA0aq7bBNcIrDzq0CV87CNyAO",
				"95aHaNs9dQGdWUb3FJyKHtX0CUiJuGlGSHQoBHCpU3iowu++K4QyeU9H9hVDCVIO",
				"/KYSVxFLVKzJ+fa0VyfbK+78b21JWdu/dAygBMSzkwnpiInqc3xEUmYQs1xlcKuT",
				"VnyPwxr1rmSXTLty7oP55oAuFspwI+VyASoBSAO0eGB5Z4M0HnSPD6qYxFm2jKh4",
				"KQ/IS9eXEqYPs/VMC3TbHt0MoNXVwqpLHz7dsOUpVmjIh6AhdQa7TZ2wEaf9IF5l",
				"69wUMnNMg9G2qEMIosJ8/kx31XfYcxUCAwEAAaOCAYkwggGFMB0GA1UdDgQWBBRd",
				"898Iygdhg/dFwJOVlmiW19jrvjCB1wYDVR0jBIHPMIHMgBRd898Iygdhg/dFwJOV",
				"lmiW19jrvqGBnaSBmjCBlzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRAwDgYD",
				"VQQHDAdGcmVtb250MRgwFgYDVQQKDA9aUEUgU3lzdGVtcyBJbmMxETAPBgNVBAsM",
				"CE5vZGVHcmlkMRUwEwYDVQQDDAxlNDFhMmMxMDAyNjAxJTAjBgkqhkiG9w0BCQEW",
				"FnN1cHBvcnRAenBlc3lzdGVtcy5jb22CFDJ9f6nFb94d4IJudvti2+7Hpl3aMAwG",
				"A1UdEwQFMAMBAf8wMQYJYIZIAYb4QgENBCQWIlRoaXMgaXMgYSBzZWxmLXNpZ25l",
				"ZCBjZXJ0aWZpY2F0ZS4wEQYJYIZIAYb4QgEBBAQDAgJEMBcGA1UdEQQQMA6CDGU0",
				"MWEyYzEwMDI2MDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZI",
				"hvcNAQELBQADggIBAA12iLESTQfuDFeGEyG4fLZhM6i+M+3RA+M7ZcFkZaDEnaPj",
				"6FM825O1V0u6gS6cTL4eZo/Kl6qWE//0voNet9GhUhnmyUirwRP+qZkB0xeF0c7m",
				"a/51ipUFHRAq040xUHHhsOJOxNVYonbBs1aSqzt2oL1t1/1Mfox0NYAmuRzo3HI1",
				"tEWybauh8/8+C3wDiwLe9WgmCQc21/3uH3+gwnBnnua+q0dOvfIrJmkxMjnah/yQ",
				"0LxRTJ36+FJRp5ExnHqTFwlB4WGznlbrK6Uy9OfrGVhGMUXl6OUscTIofVek7he/",
				"OSw8dzW1V/suD68hXGjIm55g2PeAvxwiQedlY9WusbmeP9m+c8BFy/hbpDcpEUQ5",
				"SIYnew15XXoTDzWNCSS8GxZSnZnD+VzKXIWWXsY+AZvRv9ckpmzOzRGw5m16x5Yo",
				"XYFz2uGHuLjYDOOw+y03mKwxHvPEjn2ogDOncQBjxgqj/8lK3cuhBS8pPIJJ52/g",
				"R/rsDKdXBtDgCG0fl0SBlcwr/6RiR9zpWJxK4jVKO5qGoGY/ziBKGGtRwnUbnP9T",
				"26dTHaHV2tjAf8zYIWLUQ9lvgdpQtMDo89lYVAlnpUM2Am/Unj9k2OUBJUtEoLTS",
				"rqVZePuv0UwtmNYQwXOVClPe150H26e7noFLQ1M7XNXsSdVNVJ9U1SjDCNEl",
				"-----END CERTIFICATE-----",
				""
			],
			"certificate issuer": "ZPE Systems Inc e41a2c100260",
			"certificate name": "nodegrid-default",
			"common name": "e41a2c100260",
			"country code": "US",
			"email address": "support@zpesystems.com",
			"expires on": "Jan 11 17:48:21 2028 GMT",
			"issued on": "Oct  8 17:48:21 2025 GMT",
			"key size": "4096 bit",
			"locality": "Fremont",
			"organization": "ZPE Systems Inc",
			"organization unit": "NodeGrid",
			"state": "CA",
			"status": "Valid",
			"subject alternative names": "e41a2c100260",
			"use_ssl_certificate_trust_attributes": "no"
		},
		"path": "/settings/certificates/nodegrid-default"
	}
],
```